### PR TITLE
Switch screen functionality

### DIFF
--- a/src/UnixTerminal.php
+++ b/src/UnixTerminal.php
@@ -229,6 +229,16 @@ class UnixTerminal implements Terminal
         $this->output->write(sprintf("\033[%dC", $column));
     }
 
+    public function showSecondaryScreen() : void
+    {
+        $this->output->write("\033[?47h");
+    }
+
+    public function showPrimaryScreen() : void
+    {
+        $this->output->write("\033[?47l");
+    }
+
     /**
      * Read bytes from the input stream
      */

--- a/test/UnixTerminalTest.php
+++ b/test/UnixTerminalTest.php
@@ -229,6 +229,28 @@ class UnixTerminalTest extends TestCase
         self::assertEquals("\033[10C", $output->fetch());
     }
 
+    public function testShowAlternateScreen() : void
+    {
+        $input  = $this->createMock(InputStream::class);
+        $output = new BufferedOutput;
+
+        $terminal = new UnixTerminal($input, $output);
+        $terminal->showSecondaryScreen();
+
+        self::assertEquals("\033[?47h", $output->fetch());
+    }
+
+    public function testShowMainScreen() : void
+    {
+        $input  = $this->createMock(InputStream::class);
+        $output = new BufferedOutput;
+
+        $terminal = new UnixTerminal($input, $output);
+        $terminal->showPrimaryScreen();
+
+        self::assertEquals("\033[?47l", $output->fetch());
+    }
+
     public function testRead() : void
     {
         $tempStream = fopen('php://temp', 'r+');


### PR DESCRIPTION
There's 2 "screens" that I've called main and alternate here
Switching the screen allows doing things without impact the main one

vim and less use this which is why when you quit you have no evidance of it

---

I was debating about the api for this, `switchScreen` and track internally or have two very specific methods and zero internal tracking. Let me know what you think