### PR TITLE
Catch all controls

### DIFF
--- a/src/InputCharacter.php
+++ b/src/InputCharacter.php
@@ -50,7 +50,7 @@ class InputCharacter
 
     public function isHandledControl() : bool
     {
-        return isset(static::$controls[$this->data]); 
+        return isset(static::$controls[$this->data]);
     }
 
     /**
@@ -58,7 +58,7 @@ class InputCharacter
      */
     public function isControl() : bool
     {
-        return preg_match( '/[\x00-\x1F\x7F]/', $this->data);
+        return preg_match('/[\x00-\x1F\x7F]/', $this->data);
     }
 
     /**

--- a/src/InputCharacter.php
+++ b/src/InputCharacter.php
@@ -48,12 +48,17 @@ class InputCharacter
         $this->data = $data;
     }
 
+    public function isHandledControl() : bool
+    {
+        return isset(static::$controls[$this->data]); 
+    }
+
     /**
      * Is this character a control sequence?
      */
     public function isControl() : bool
     {
-        return isset(static::$controls[$this->data]);
+        return preg_match( '/[\x00-\x1F\x7F]/', $this->data);
     }
 
     /**

--- a/test/InputCharacterTest.php
+++ b/test/InputCharacterTest.php
@@ -15,6 +15,7 @@ class InputCharacterTest extends TestCase
         $char = new InputCharacter("\n");
 
         self::assertTrue($char->isControl());
+        self::assertTrue($char->isHandledControl());
         self::assertFalse($char->isNotControl());
         self::assertEquals('ENTER', $char->getControl());
         self::assertEquals("\n", $char->get());
@@ -26,6 +27,7 @@ class InputCharacterTest extends TestCase
         $char = new InputCharacter('p');
 
         self::assertFalse($char->isControl());
+        self::assertFalse($char->isHandledControl());
         self::assertTrue($char->isNotControl());
         self::assertEquals('p', $char->get());
         self::assertEquals('p', $char->__toString());
@@ -82,5 +84,18 @@ class InputCharacterTest extends TestCase
     {
         self::assertTrue(InputCharacter::controlExists(InputCharacter::UP));
         self::assertFalse(InputCharacter::controlExists('w'));
+    }
+
+    public function testIsControlOnNotExplicitlyHandledControls() : void
+    {
+        $char = new InputCharacter("\016"); //ctrl + p (I think)
+
+        self::assertTrue($char->isControl());
+        self::assertFalse($char->isHandledControl());
+
+        $char = new InputCharacter("\021"); //ctrl + u (I think)
+
+        self::assertTrue($char->isControl());
+        self::assertFalse($char->isHandledControl());
     }
 }

--- a/test/InputCharacterTest.php
+++ b/test/InputCharacterTest.php
@@ -98,4 +98,15 @@ class InputCharacterTest extends TestCase
         self::assertTrue($char->isControl());
         self::assertFalse($char->isHandledControl());
     }
+
+    public function testUnicodeCharacter() : void
+    {
+        $char = new InputCharacter('ß');
+
+        self::assertFalse($char->isControl());
+        self::assertFalse($char->isHandledControl());
+        self::assertTrue($char->isNotControl());
+        self::assertEquals('ß', $char->get());
+        self::assertEquals('ß', $char->__toString());
+    }
 }


### PR DESCRIPTION
Updated so that `isControl` will return true for anything that is a control signal (hopefully) - basically ASCII characters 0-31 and 127.

Also added a `isHandledControl` that returns true if it's a control and one we allow to handle ( we can update the list of handled ones whenever we want really - but I'd just leave it until we need them)