### PR TITLE
add getColourSupport()

### DIFF
--- a/src/UnixTerminal.php
+++ b/src/UnixTerminal.php
@@ -34,6 +34,11 @@ class UnixTerminal implements Terminal
      * @var int
      */
     private $height;
+    
+    /**
+     * @var int;
+     */
+    private $colourSupport;
 
     /**
      * @var string
@@ -72,6 +77,11 @@ class UnixTerminal implements Terminal
     public function getHeight() : int
     {
         return $this->height ?: $this->height = (int) exec('tput lines');
+    }
+
+    public function getColourSupport() : int
+    {
+        return $this->colourSupport ?: $this->colourSupport = (int) exec('tput colors');
     }
 
     private function getOriginalConfiguration() : string

--- a/test/UnixTerminalTest.php
+++ b/test/UnixTerminalTest.php
@@ -292,6 +292,8 @@ class UnixTerminalTest extends TestCase
 
         $terminal = new UnixTerminal($input, $output);
 
-        self::assertEquals(0, $terminal->getColourSupport());
+        // Travis terminal supports 8 colours, but just in case
+        // in ever changes I'll add the 256 colors possibility too
+        self::assertTrue($terminal->getColourSupport() === 8 || $terminal->getColourSupport() === 256);
     }
 }

--- a/test/UnixTerminalTest.php
+++ b/test/UnixTerminalTest.php
@@ -295,5 +295,8 @@ class UnixTerminalTest extends TestCase
         // Travis terminal supports 8 colours, but just in case
         // in ever changes I'll add the 256 colors possibility too
         self::assertTrue($terminal->getColourSupport() === 8 || $terminal->getColourSupport() === 256);
+        
+        var_dump(exec('infocmp screen'));
+        exit();
     }
 }

--- a/test/UnixTerminalTest.php
+++ b/test/UnixTerminalTest.php
@@ -295,8 +295,5 @@ class UnixTerminalTest extends TestCase
         // Travis terminal supports 8 colours, but just in case
         // in ever changes I'll add the 256 colors possibility too
         self::assertTrue($terminal->getColourSupport() === 8 || $terminal->getColourSupport() === 256);
-        
-        var_dump(exec('infocmp screen'));
-        exit();
     }
 }

--- a/test/UnixTerminalTest.php
+++ b/test/UnixTerminalTest.php
@@ -284,4 +284,14 @@ class UnixTerminalTest extends TestCase
 
         self::assertEquals('My awesome string', $output->fetch());
     }
+
+    public function testGetColourSupport() : void
+    {
+        $input  = $this->createMock(InputStream::class);
+        $output = new BufferedOutput;
+
+        $terminal = new UnixTerminal($input, $output);
+
+        self::assertEquals(0, $terminal->getColourSupport());
+    }
 }


### PR DESCRIPTION
Return the number of colours the terminal can handle (usually something like 8 or 256).

Needed for https://github.com/php-school/cli-menu/pull/104