### PR TITLE
Disable blocking when input detected.

### DIFF
--- a/src/IO/ResourceInputStream.php
+++ b/src/IO/ResourceInputStream.php
@@ -34,6 +34,14 @@ class ResourceInputStream implements InputStream
     public function read(int $numBytes, callable $callback) : void
     {
         $buffer = fread($this->stream, $numBytes);
+        if (!empty($buffer)) {
+            // Prevent blocking to handle pasted input.
+            stream_set_blocking($this->stream, false);
+        } else {
+            // Re-enable blocking when input has been handled.
+            stream_set_blocking($this->stream, true);
+        }
+
         $callback($buffer);
     }
 


### PR DESCRIPTION
To handled copy-paste behaviour, all available input should be read immediately. So, we turn blocking off when input is available, and turn it back on when no further input is available.